### PR TITLE
コメントで初めてリアクションをつけるときに、付けれないバグを修正

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -51,8 +51,11 @@ class TopicsController < ApplicationController
 
     map[:topic][:order] = @topic.reactions.pluck(:icon_id).uniq
     map_ids = @topic.comment_reactions.pluck(:reactionable_id, :icon_id).uniq
+    comment_ids = @topic.comments.ids
+    comment_ids.each do |comment_id|
+      map[:comment][comment_id][:order] = []
+    end
     map_ids.each do |comment_id, icon_id|
-      map[:comment][comment_id][:order] ||= []
       map[:comment][comment_id][:order] << icon_id
     end
     render json: map, status: 200

--- a/app/javascript/packs/mixins/reaction.js
+++ b/app/javascript/packs/mixins/reaction.js
@@ -19,9 +19,14 @@ export default {
       })
       .then(function(res) {
         self.$store.dispatch('createReaction', res.data)
+        console.log("createReaction success")
       })
       .catch(function(err) {
-        self.$store.dispatch('errorReaction', err.response.data)
+        if(err.response !== undefined) {
+          self.$store.dispatch('errorReaction', err.response.data)
+        } else {
+          console.log(err)
+        }
         console.log("createReaction fail")
       })
     },


### PR DESCRIPTION
## 原因

storeの中のcommentのorderの値に初期値に空の配列がなかったため。